### PR TITLE
use esprima to parse the file instead of searching for sub-strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "grunt"
   ],
   "author": "Brian Ford",
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "esprima": "~1.0.4"
+  }
 }

--- a/tests/simple.js
+++ b/tests/simple.js
@@ -26,10 +26,23 @@ describe('check-file', function () {
     should.exist(checkFile("xdescribe('is not a-ok')"));
   });
 
-  it('should give the line number of the problem', function () {
+  it('should disallow only function calls', function () {
+    should.not.exist(checkFile("it('xit here is a-ok')"));
+  });
+
+  it('should traverse the syntax tree', function () {
+    should.exist(checkFile("describe('is a-ok', function () { iit('is not a-ok'); })"));
+  });
+
+  it('should return undefined if the parse fails', function () {
+    should.not.exist(checkFile("xit('is not a-ok, but I forgot to close)"));
+  });
+
+  it('should give the line number and str of the problem', function () {
     var problems = checkFile("\n\niit('is not a-ok')");
     problems.length.should.equal(1);
     should.equal(problems[0].line, 3);
+    should.equal(problems[0].str, 'iit');
   });
 
 });


### PR DESCRIPTION
The previous implementation had a lot of false negatives.
For example, 'xit' is a sub-string of 'exit'.
