### PR TITLE
Make parsing smarter, e.g. don't match `xit` in `exit`.

### DIFF
--- a/tasks/lib/check-file.js
+++ b/tasks/lib/check-file.js
@@ -5,25 +5,24 @@ var disallowed = [
   'xdescribe'
 ];
 
-var whitespace = [
-  ' ',
-  '\n',
-  '\t'
-];
+function disallowedIndex(largeString, disallowedString) {
+  var notFunctionName = '[^A-Za-z0-9$_]';
+  var regex = new RegExp('(^|' + notFunctionName + ')(' + disallowedString + ')' + notFunctionName + '*\\(', 'gm');
+  var match = regex.exec(largeString);
+  // Return the match accounting for the first submatch length.
+  return match != null ? match.index + match[1].length : -1;
+}
 
 // returns undefined || obj
 module.exports = function (fileContents) {
   var res;
 
   disallowed.forEach(function (str) {
-    var index = 0;
-    if ((index = fileContents.indexOf(str)) !== -1 &&
-        (index === 0 || whitespace.indexOf(fileContents[index - 1]) > -1)) {
-
+    if (disallowedIndex(fileContents, str) !== -1) {
       res = res || [];
       res.push({
         str: str,
-        line: fileContents.substr(0, fileContents.indexOf(str)).split('\n').length
+        line: fileContents.substr(0, disallowedIndex(fileContents, str)).split('\n').length
       });
     }
   });

--- a/tests/simple.js
+++ b/tests/simple.js
@@ -22,14 +22,27 @@ describe('check-file', function () {
     should.exist(checkFile("xit('is not a-ok')"));
   });
 
+  it('should return an array if there is `xit` after `exit`', function () {
+    should.exist(checkFile("exit(0);xit('is not a-ok')"));
+    should.exist(checkFile("it('is a-ok');exit(0);xit('is not a-ok')"));
+  });
+
   it('should return an array if there is `xdescribe`', function () {
     should.exist(checkFile("xdescribe('is not a-ok')"));
   });
 
   it('should give the line number of the problem', function () {
-    var problems = checkFile("\n\niit('is not a-ok')");
+    var problems = checkFile("ddescribe('is not a-ok')");
+    problems.length.should.equal(1);
+    should.equal(problems[0].line, 1);
+
+    problems = checkFile("\n\niit('is not a-ok')");
     problems.length.should.equal(1);
     should.equal(problems[0].line, 3);
+
+    problems = checkFile("\n\n\n\n\nxit('is not a-ok')");
+    problems.length.should.equal(1);
+    should.equal(problems[0].line, 6);
   });
 
   it('should not treat `exit` as `xit`', function () {


### PR DESCRIPTION
Current `ddescribe-iit` parsing is way too simple, it even matches things like `'exit'` somewhere inside the code as invalid since it contains the `xit` substring. I made it smarter.

Commit summary:
1) Make parsing smarter, e.g. don't match `xit` in `exit`.
2) Corrected `grunt jshint` output, created a separate jshint target for tests/
3) Added .gitignore & .gitattributes.

I put it in 3 different commits since it makes sence semantically but merge it however you want.
